### PR TITLE
Adding Guzzle verify option into the constructor

### DIFF
--- a/src/LaravelMsg91.php
+++ b/src/LaravelMsg91.php
@@ -65,7 +65,8 @@ class LaravelMsg91 {
 		$this->limit_credit = config('laravel-msg91.limit_credit');
 		$this->country = config('laravel-msg91.country');
 		$base_uri = config('laravel-msg91.base_uri') ? config('laravel-msg91.base_uri') : 'https://control.msg91.com/api/'; 
-		$this->guzzle = new GuzzleClient(["base_uri" => $base_uri ]);
+		$guzzleVerify = config('laravel-msg91.guzzle_verify', true);
+		$this->guzzle = new GuzzleClient(["base_uri" => $base_uri, "verify" => $guzzleVerify]);
 	}
 
 


### PR DESCRIPTION
Adding Guzzle verify option into the constructor.  In some local environment  people get 'cURL error 60: SSL certificate problem'. that can be avoided with this option.
```
$guzzleVerify = config('laravel-msg91.guzzle_verify', true);
        $this->guzzle = new GuzzleClient(["base_uri" => $base_uri, "verify" => $guzzleVerify]);
```