### PR TITLE
Adding Guzzle verify option into the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Laravel 5 Msg91 package
-[![Latest Stable Version](http://img.shields.io/badge/Latest%20Stable-1.0.1-blue.svg)](https://packagist.org/packages/robincsamuel/laravel-msg91)
+<!-- [![Latest Stable Version](http://img.shields.io/badge/Latest%20Stable-1.0.1-blue.svg)](https://packagist.org/packages/robincsamuel/laravel-msg91) -->
 
 ### About
 
@@ -17,11 +17,11 @@ MSG91 is a bulk SMS service provider offers transactional & promotional bulk SMS
 
 Installation via composer
 
-Add `robincsamuel/laravel-msg91` to your composer requirements:
+Add `devduttabain/laravel-msg91` to your composer requirements:
 
 ```php
 "require": {
-    "robincsamuel/laravel-msg91": "dev-master"
+    "devduttabain/laravel-msg91": "dev-develop"
 }
 ```
 
@@ -30,13 +30,13 @@ Now run `composer update`
 Once the package is installed, open your `app/config/app.php` configuration file and locate the `providers` key. Add the following line to the end:
 
 ```php
-RobinCSamuel\LaravelMsg91\LaravelMsg91ServiceProvider::class
+DevD\LaravelMsg91\LaravelMsg91ServiceProvider::class
 ```
 
 Next, locate the `aliases` key and add the following line:
 
 ```php
-'LaravelMsg91' => RobinCSamuel\LaravelMsg91\Facades\LaravelMsg91::class,
+'LaravelMsg91' => DevD\LaravelMsg91\Facades\LaravelMsg91::class,
 ```
 
 Put the credentials & preferences in ENV with the keys `MSG91_KEY`, `MSG91_SENDER_ID`, `MSG91_ROUTE`, `MSG91_COUNTRY`.
@@ -87,6 +87,9 @@ $ php artisan vendor:publish
 
    $result = LaravelMsg91::verifyOtp(919090909090, 1290, ['raw' => true]); // returns what msg91 replies (includes error message & type)
    ```
+
+### Original Repo
+   Original repo by   [Robin C Samuel](https://github.com/robincsamuel/laravel-msg91)
 
 ### License
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
         {
             "name": "Robin C Samuel",
             "email": "hi@robinz.in"
+        },
+        {
+            "name": "Devdutta Bain",
+            "email": "namste@dev.duttaba.in"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "robincsamuel/laravel-msg91",
+    "name": "devduttabain/laravel-msg91",
     "description": "Package for MSG91 sms API",
     "require": {
         "guzzlehttp/guzzle": "^6.2"
@@ -18,7 +18,7 @@
             "src"
         ],
         "psr-4": {
-            "RobinCSamuel\\LaravelMsg91\\": "src/"
+            "DevD\\LaravelMsg91\\": "src/"
         }
     }
 }

--- a/src/Facades/LaravelMsg91.php
+++ b/src/Facades/LaravelMsg91.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RobinCSamuel\LaravelMsg91\Facades;
+namespace DevD\LaravelMsg91\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/LaravelMsg91.php
+++ b/src/LaravelMsg91.php
@@ -65,7 +65,8 @@ class LaravelMsg91 {
 		$this->limit_credit = config('laravel-msg91.limit_credit');
 		$this->country = config('laravel-msg91.country');
 		$base_uri = config('laravel-msg91.base_uri') ? config('laravel-msg91.base_uri') : 'https://control.msg91.com/api/'; 
-		$this->guzzle = new GuzzleClient(["base_uri" => $base_uri ]);
+        $guzzleVerify = config('laravel-msg91.guzzle_verify', true);
+        $this->guzzle = new GuzzleClient(["base_uri" => $base_uri, "verify" => $guzzleVerify]);
 	}
 
 

--- a/src/LaravelMsg91ServiceProvider.php
+++ b/src/LaravelMsg91ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RobinCSamuel\LaravelMsg91;
+namespace DevD\LaravelMsg91;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,8 @@ return array(
 	/* Credit limit, if true message will be limted to 1 credit (optional) */
 	'limit_credit' => env('MSG91_LIMIT_CREDIT', false),
 
+	/* Guzzle Verify, if false there'll be no ssl checking (optional) */
+	'guzzle_verify' => env('MSG91_GUZZLE_VERIFY', true),
+
+	
 );


### PR DESCRIPTION
Adding Guzzle verify option into the constructor. In some local environment people get 'cURL error 60: SSL certificate problem'. that can be avoided with this option.

```
$guzzleVerify = config('laravel-msg91.guzzle_verify', true);
$this->guzzle = new GuzzleClient(["base_uri" => $base_uri, "verify" => $guzzleVerify]);
```

And to the config file...
```
	/* Guzzle Verify, if false there'll be no ssl checking (optional) */
	'guzzle_verify' => env('MSG91_GUZZLE_VERIFY', true),
```