### PR TITLE
Laravel Upgrade 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "robincsamuel/laravel-msg91",
     "description": "Package for MSG91 sms API",
     "require": {
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.0.1"
     },
     "keywords": ["laravel-msg91", "msg91 laravel", "msg91 laravel package", "laravel package", "laravel sms package", "sms api", "text api"],
     "license": "MIT",


### PR DESCRIPTION
Laravel 8 uses Guzzle version 7.0.1, we need to upgrade version to support this package on laravel version 8.