### PR TITLE
Adding Guzzle verify option into the constructor

### DIFF
--- a/src/LaravelMsg91.php
+++ b/src/LaravelMsg91.php
@@ -65,7 +65,10 @@ class LaravelMsg91 {
 		$this->limit_credit = config('laravel-msg91.limit_credit');
 		$this->country = config('laravel-msg91.country');
 		$base_uri = config('laravel-msg91.base_uri') ? config('laravel-msg91.base_uri') : 'https://control.msg91.com/api/'; 
-		$this->guzzle = new GuzzleClient(["base_uri" => $base_uri ]);
+		
+		//reading verify option from config, and passing that to the guzzle options
+		$guzzleVerify = config('laravel-msg91.guzzle_verify', true);
+		$this->guzzle = new GuzzleClient(["base_uri" => $base_uri, "verify" => $guzzleVerify]);
 	}
 
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,7 @@ return array(
 	/* Credit limit, if true message will be limted to 1 credit (optional) */
 	'limit_credit' => env('MSG91_LIMIT_CREDIT', false),
 
+	/* Guzzle Verify, if false there'll be no ssl checking (optional) */
+	'guzzle_verify' => env('MSG91_GUZZLE_VERIFY', true),
+
 );


### PR DESCRIPTION
Adding Guzzle verify option into the constructor. In some local environment people get 'cURL error 60: SSL certificate problem'. that can be avoided with this option.

```
$guzzleVerify = config('laravel-msg91.guzzle_verify', true);
$this->guzzle = new GuzzleClient(["base_uri" => $base_uri, "verify" => $guzzleVerify]);
```

And to the config file...
```
	/* Guzzle Verify, if false there'll be no ssl checking (optional) */
	'guzzle_verify' => env('MSG91_GUZZLE_VERIFY', true),
```